### PR TITLE
Upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,6 @@ Sphinx
 sphinx-autobuild
 pytest
 pytest-cov
+pytest-capturelog
 flake8
 wheel

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -150,6 +150,10 @@ class TestAPIClient(TestCase):
         times, impacts = self.impacter.fetch(self.start_at, self.end_at,
                                              ba='PJM', market='RT5M')
 
+        # same amount of data
+        self.assertEqual(len(series), len(impacts))
+
+        # same values
         for i in range(len(times)):
             self.assertEqual(series.at[times[i]], impacts[i])
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -138,8 +138,7 @@ class TestAPIClient(TestCase):
         value_pre = self.impacter.get_impact_at(off_hr_ts, ba='PJM', market='RT5M')
 
         # overwrite cache with just the earlier timestamp and fake value
-        fake_cached_data = {on_hr_ts: -1000}
-        self.impacter.cache.set(on_hr_key, fake_cached_data)
+        self.impacter.insert_to_cache(on_hr_ts, 'PJM', 'RT5M', -1000)
 
         # get again, should be correct value
         value_post = self.impacter.get_impact_at(off_hr_ts, ba='PJM', market='RT5M')
@@ -150,6 +149,7 @@ class TestAPIClient(TestCase):
                                                   interval_minutes=5, ba='PJM')
         times, impacts = self.impacter.fetch(self.start_at, self.end_at,
                                              ba='PJM', market='RT5M')
+
         for i in range(len(times)):
             self.assertEqual(series.at[times[i]], impacts[i])
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,8 +8,11 @@ import os
 
 class TestAPIClient(TestCase):
     def setUp(self):
+        # set up client
         WATTTIME_API_TOKEN = os.environ.get('WATTTIME_API_TOKEN')
         self.impacter = WattTimeAPI(token=WATTTIME_API_TOKEN)
+
+        # set up times
         self.start_at = datetime(2014, 9, 2, 23, tzinfo=pytz.utc)
         self.end_at = datetime(2014, 9, 3, 2, tzinfo=pytz.utc)
         self.early_date = datetime(1914, 9, 2, 23, tzinfo=pytz.utc)

--- a/watttime_client/client.py
+++ b/watttime_client/client.py
@@ -46,7 +46,7 @@ class WattTimeAPI(object):
         params.update(kwargs)
 
         # make request
-        result = requests.get('http://api.watttime.org/api/v1/marginal/',
+        result = requests.get('https://api.watttime.org/api/v1/marginal/',
                               params=params, headers=self.auth_header)
         data = result.json()['results']
 
@@ -87,12 +87,12 @@ class WattTimeAPI(object):
             if lag_time < timedelta(hours=1) and market == 'DAHR':
                 # acceptable lag is 1 hr for hourly data
                 return best_cached_value
-            elif lag_time < timedelta(minutes=5):
-                # acceptablelag is 5 min otherwise
+            elif lag_time < timedelta(minutes=15):
+                # acceptable lag is 15 min otherwise
                 return best_cached_value
 
         # if got here, no good data in cache, so fetch it
-        times, values = self.fetch(ts - timedelta(hours=1), ts + timedelta(hours=1), ba, market)
+        times, values = self.fetch(ts - timedelta(hours=4), ts + timedelta(hours=4), ba, market)
 
         # best value is latest time before or equal to ts
         best_value = None
@@ -127,7 +127,7 @@ class WattTimeAPI(object):
         dtidx = pd.date_range(utc_start, utc_end, freq='%dMin' % interval_minutes)
 
         # get cached value for every timestamp
-        values = dtidx.map(lambda ts: self.best_cached_value(ts, ba, market)[1])
+        values = dtidx.map(lambda ts: self.best_cached_value(ts, ba, market)[0])
 
         # set up series
         series = pd.Series(values, index=dtidx)
@@ -198,7 +198,7 @@ class WattTimeAPI(object):
         best_time, best_value = None, None
         for d, v in zip(times, values):
             if d <= ts:
-                best_time = ts
+                best_time = d
                 best_value = v
             else:
                 break

--- a/watttime_client/client.py
+++ b/watttime_client/client.py
@@ -127,15 +127,10 @@ class WattTimeAPI(object):
         dtidx = pd.date_range(utc_start, utc_end, freq='%dMin' % interval_minutes)
 
         # get cached value for every timestamp
-        values = dtidx.map(lambda ts: self.best_cached_value(ts, ba, market)[0])
+        values = dtidx.map(lambda ts: self.get_impact_at(ts, ba, market))
 
         # set up series
         series = pd.Series(values, index=dtidx)
-
-        # for uncached values, fill with fetch
-        for ts, value in series.where(series.isnull()).iteritems():
-            series.at[ts] = self.get_impact_at(ts, ba, market)
-            logger.debug('%s %s' % (ts, series.at[ts]))
 
         # fill any remaining null values
         if fill:


### PR DESCRIPTION
* http -> https
* log warning if Django cache is unavailable
* log debug info for every API request
* attempt to reduce external request count by using `best_cached_value` if within 15 min (real-time) or 1 hr (forecast) of timestamp