### PR TITLE
change python to 3.8+, add dateutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,9 +7,6 @@ setup(
         WattTime API, including data that spans across the 30 day API request limit.""",
     version="3.0",
     packages=["watttime_sdk"],
-    python_requires=">=3.7",
-    install_requires=[
-        "requests",
-        "pandas>1.0.0"
-    ]
+    python_requires=">=3.8",
+    install_requires=["requests", "pandas>1.0.0", "python-dateutil"],
 )


### PR DESCRIPTION
Python 3.7 is past its EOL and also does not include `Literal` in its typing library, so it will cause an error. Instead of trying to fix this, we should just require 3.8+

Also added python-dateutil as a requirement.