### PR TITLE
Request to add custom SSL certificate verification

### DIFF
--- a/watttime/api.py
+++ b/watttime/api.py
@@ -126,7 +126,7 @@ class WattTimeBase:
             "org": organization,
         }
 
-        rsp = requests.post(url, json=params, timeout=20)
+        rsp = requests.post(url, json=params, verify=self.certificate_location, timeout=20)
         rsp.raise_for_status()
         print(
             f"Successfully registered {self.username}, please check {email} for a verification email"
@@ -163,7 +163,7 @@ class WattTimeBase:
             "longitude": str(longitude),
             "signal_type": signal_type,
         }
-        rsp = requests.get(url, headers=headers, params=params)
+        rsp = requests.get(url, headers=headers, params=params, verify=self.certificate_location)
         if not rsp.ok:
             if rsp.status_code == 404:
                 # here we specifically cannot find a location that was provided
@@ -219,7 +219,7 @@ class WattTimeHistorical(WattTimeBase):
 
         for c in chunks:
             params["start"], params["end"] = c
-            rsp = requests.get(url, headers=headers, params=params)
+            rsp = requests.get(url, headers=headers, params=params, verify=self.certificate_location)
             try:
                 rsp.raise_for_status()
                 j = rsp.json()
@@ -325,7 +325,7 @@ class WattTimeMyAccess(WattTimeBase):
             self._login()
         url = "{}/v3/my-access".format(self.url_base)
         headers = {"Authorization": "Bearer " + self.token}
-        rsp = requests.get(url, headers=headers)
+        rsp = requests.get(url, headers=headers, verify=self.certificate_location)
         rsp.raise_for_status()
         return rsp.json()
 
@@ -409,7 +409,7 @@ class WattTimeForecast(WattTimeBase):
 
         url = "{}/v3/forecast".format(self.url_base)
         headers = {"Authorization": "Bearer " + self.token}
-        rsp = requests.get(url, headers=headers, params=params)
+        rsp = requests.get(url, headers=headers, params=params, verify=self.certificate_location)
         rsp.raise_for_status()
         return rsp.json()
 
@@ -488,7 +488,7 @@ class WattTimeForecast(WattTimeBase):
 
         for c in chunks:
             params["start"], params["end"] = c
-            rsp = requests.get(url, headers=headers, params=params)
+            rsp = requests.get(url, headers=headers, params=params, verify=self.certificate_location)
             try:
                 rsp.raise_for_status()
                 j = rsp.json()
@@ -565,6 +565,6 @@ class WattTimeMaps(WattTimeBase):
         url = "{}/v3/maps".format(self.url_base)
         headers = {"Authorization": "Bearer " + self.token}
         params = {"signal_type": signal_type}
-        rsp = requests.get(url, headers=headers, params=params)
+        rsp = requests.get(url, headers=headers, params=params, verify=self.certificate_location)
         rsp.raise_for_status()
         return rsp.json()

--- a/watttime/api.py
+++ b/watttime/api.py
@@ -24,6 +24,7 @@ class WattTimeBase:
         """
         self.username = username or os.getenv("WATTTIME_USER")
         self.password = password or os.getenv("WATTTIME_PASSWORD")
+        self.certificate_location = os.getenv("PEM_CERTIFICATE")
         self.token = None
         self.token_valid_until = None
 
@@ -39,6 +40,7 @@ class WattTimeBase:
         rsp = requests.get(
             url,
             auth=requests.auth.HTTPBasicAuth(self.username, self.password),
+            verify=self.certificate_location,
             timeout=20,
         )
         rsp.raise_for_status()


### PR DESCRIPTION
Issue #24 

Currently, watttime/api.py does not specify custom SSL certificate verification when making requests to the WattTime API, instead, it uses the system defaults. For enhanced security and compatibility with specific certificate requirements, we need to update the function to use a custom certificate location for SSL verification.

This would be really useful in the cases where we would need to trust a specific certificate and would improve the security and compatibility of the API login process.