### PR TITLE
Add typical carbon year (TCY) functionality 

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ wt.get_maps_json('co2_moer')
 The SDK provides functionality to calculate a Typical Carbon Year (TCY) profile, which represents typical MOER patterns over a year by combining three years of historical data. A TCY accounts for seasonal variations, daily patterns, and differences between weekdays and weekends/holidays:
 
 ```python
-from watttime import TCYConfig, TCYCalculator
+from watttime import TCYCalculator
 
 # Initialize calculator (using env variables for credentials)
 calculator = TCYCalculator(
@@ -169,8 +169,9 @@ calculator = TCYCalculator(
 tcy_profile = calculator.calculate_tcy(2024)
 ```
 
-The returned tcy_profile is a pandas series with hourly timestamps in the specified timezone and corresponding MOER values (in lbs CO2/MWh). The profile provides hourly values that represent typical grid emissions patterns for the region. This can be useful for:
-* Building energy modeling and optimization
+The returned tcy_profile is a pandas series with hourly timestamps in the specified timezone and corresponding MOER values (in lbs CO2/MWh). The profile provides hourly values that represent typical grid emissions patterns for the region. Note that this data has a lower variance than real-time MOER data, so it should not be used to estimate the carbon reduction opportunity from load-shifting/AER.
+
+This can be useful for:
+
+* Estimating the relative carbon impact of building design choices
 * Understanding typical emissions patterns in a region
-* Planning load shifting strategies
-* Analyzing weekday vs weekend patterns

--- a/README.md
+++ b/README.md
@@ -144,3 +144,27 @@ wt.region_from_loc(
 # get shape files for all regions of a signal type
 wt.get_maps_json('co2_moer')
 ```
+
+### Calculating a Typical Carbon Year (TCY)
+The SDK provides functionality to calculate a Typical Carbon Year (TCY) profile, which represents typical MOER patterns over a year by analyzing three years of historical data. A TCY accounts for seasonal variations, daily patterns, and differences between weekdays and weekends/holidays:
+
+```python
+from watttime import TCYConfig, TCYCalculator
+
+# Configure TCY calculation
+config = TCYConfig(
+    region="CAISO_NORTH",
+    timezone="America/Los_Angeles"  # Local timezone for the region
+)
+
+# Initialize calculator
+calculator = TCYCalculator(username, password, config)
+
+# Calculate TCY for a specific year
+tcy_profile = calculator.calculate_tcy(2024)
+```
+The returned tcy_profile is a pandas series with hourly timestamps in the specified timezone and corresponding MOER values (in lbs CO2/MWh). The profile provides hourly values that represent typical grid emissions patterns for the region. This can be useful for:
+* Building energy modeling and optimization
+* Understanding typical emissions patterns in a region
+* Planning load shifting strategies
+* Analyzing weekday vs weekend patterns

--- a/README.md
+++ b/README.md
@@ -151,12 +151,6 @@ The SDK provides functionality to calculate a Typical Carbon Year (TCY) profile,
 ```python
 from watttime import TCYConfig, TCYCalculator
 
-# Configure TCY calculation
-config = TCYConfig(
-    region="CAISO_NORTH",
-    timezone="America/Los_Angeles"  # Local timezone for the region
-)
-
 # Initialize calculator (using env variables for credentials)
 calculator = TCYCalculator(
     region="CAISO_NORTH",
@@ -171,9 +165,10 @@ calculator = TCYCalculator(
     password="your_password"
 )
 
-# Calculate TCY for a specific year
+# Calculate TCY for any year (uses recent MOER patterns with target year's calendar)
 tcy_profile = calculator.calculate_tcy(2024)
 ```
+
 The returned tcy_profile is a pandas series with hourly timestamps in the specified timezone and corresponding MOER values (in lbs CO2/MWh). The profile provides hourly values that represent typical grid emissions patterns for the region. This can be useful for:
 * Building energy modeling and optimization
 * Understanding typical emissions patterns in a region

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ wt.get_maps_json('co2_moer')
 ```
 
 ### Calculating a Typical Carbon Year (TCY)
-The SDK provides functionality to calculate a Typical Carbon Year (TCY) profile, which represents typical MOER patterns over a year by analyzing three years of historical data. A TCY accounts for seasonal variations, daily patterns, and differences between weekdays and weekends/holidays:
+The SDK provides functionality to calculate a Typical Carbon Year (TCY) profile, which represents typical MOER patterns over a year by combining three years of historical data. A TCY accounts for seasonal variations, daily patterns, and differences between weekdays and weekends/holidays:
 
 ```python
 from watttime import TCYConfig, TCYCalculator

--- a/README.md
+++ b/README.md
@@ -157,8 +157,19 @@ config = TCYConfig(
     timezone="America/Los_Angeles"  # Local timezone for the region
 )
 
-# Initialize calculator
-calculator = TCYCalculator(username, password, config)
+# Initialize calculator (using env variables for credentials)
+calculator = TCYCalculator(
+    region="CAISO_NORTH",
+    timezone="America/Los_Angeles"
+)
+
+# Or with explicit credentials
+calculator = TCYCalculator(
+    region="CAISO_NORTH",
+    timezone="America/Los_Angeles",
+    username="your_username",
+    password="your_password"
+)
 
 # Calculate TCY for a specific year
 tcy_profile = calculator.calculate_tcy(2024)

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(
     version="v1.2.1",
     packages=["watttime"],
     python_requires=">=3.8",
-    install_requires=["requests", "pandas>1.0.0", "python-dateutil"],
+    install_requires=["requests", "pandas>1.0.0", "holidays", "python-dateutil"],
 )

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -9,7 +9,7 @@ from watttime import (
     WattTimeHistorical,
     WattTimeMyAccess,
     WattTimeForecast,
-    WattTimeMaps,
+    WattTimeMaps
 )
 from pathlib import Path
 

--- a/tests/test_tcy.py
+++ b/tests/test_tcy.py
@@ -18,9 +18,9 @@ class TestTCY(unittest.TestCase):
     def test_tcy_weekday_weekend_differentiation(self):
         """Test that TCY properly differentiates between weekdays and weekends"""
         dates = pd.date_range(
-            start='2023-01-01', 
+            start='2023-01-01',
             end='2023-01-31',
-            freq='H',
+            freq='h',
             tz='America/Los_Angeles'
         )
         values = [100 if self.calculator._is_weekday(d) else 200 for d in dates]
@@ -29,25 +29,34 @@ class TestTCY(unittest.TestCase):
         ref_table = self.calculator._create_reference_table(test_data)
 
         weekday_value = ref_table[
-            (ref_table['month'] == 1) & 
-            (ref_table['hour'] == 12) & 
+            (ref_table['month'] == 1) &
+            (ref_table['hour'] == 12) &
             (ref_table['is_weekday'] == True)
         ]['value'].iloc[0]
         weekend_value = ref_table[
-            (ref_table['month'] == 1) & 
-            (ref_table['hour'] == 12) & 
+            (ref_table['month'] == 1) &
+            (ref_table['hour'] == 12) &
             (ref_table['is_weekday'] == False)
         ]['value'].iloc[0]
         
         self.assertEqual(weekday_value, 100)
         self.assertEqual(weekend_value, 200)
 
-    def test_tcy_new_years_holiday(self):
-        """Test that New Year's Day is treated as a weekend/holiday"""
-        new_years = pd.Timestamp('2024-01-01', tz='America/Los_Angeles')
-        self.assertFalse(self.calculator._is_weekday(new_years))
+    def test_tcy_holiday_handling(self):
+        """Test that holidays are correctly identified for different years"""
+        # Test current year holiday
+        new_years_2024 = pd.Timestamp('2024-01-01', tz='America/Los_Angeles')
+        self.assertFalse(self.calculator._is_weekday(new_years_2024))
         
-        # Test same date but not a holiday
+        # Test past year holiday
+        new_years_2018 = pd.Timestamp('2018-01-01', tz='America/Los_Angeles')
+        self.assertFalse(self.calculator._is_weekday(new_years_2018))
+        
+        # Test future year holiday
+        new_years_2025 = pd.Timestamp('2025-01-01', tz='America/Los_Angeles')
+        self.assertFalse(self.calculator._is_weekday(new_years_2025))
+        
+        # Test regular weekday
         regular_day = pd.Timestamp('2024-01-02', tz='America/Los_Angeles')
         self.assertTrue(self.calculator._is_weekday(regular_day))
 
@@ -65,6 +74,27 @@ class TestTCY(unittest.TestCase):
         self.assertEqual(tcy.index.tz.zone, "America/Los_Angeles")
         self.assertEqual(str(tcy.index[0])[:4], "2024")  # Starts at beginning of year
         self.assertTrue('-08:00' in str(tcy.index[0]) or '-07:00' in str(tcy.index[0]))  # Pacific time
+
+    def test_tcy_different_years_same_pattern(self):
+        """Test that different target years use same recent data patterns"""
+        # Calculate TCY for different years
+        tcy_2018 = self.calculator.calculate_tcy(2018)
+        tcy_2024 = self.calculator.calculate_tcy(2024)
+
+        # Same calendar pattern days (e.g., first Wednesday of January at 2pm)
+        # should have similar values despite different years
+        jan_2018_wed = tcy_2018['2018-01-03 14:00:00-08:00']  # A Wednesday
+        jan_2024_wed = tcy_2024['2024-01-03 14:00:00-08:00']  # A Wednesday
+        
+        self.assertEqual(jan_2018_wed, jan_2024_wed)
+
+        # But holidays should follow their respective years
+        new_years_2018 = tcy_2018['2018-01-01 12:00:00-08:00']
+        new_years_2024 = tcy_2024['2024-01-01 12:00:00-08:00']
+        
+        # Both should use holiday patterns (different from weekday patterns)
+        self.assertNotEqual(new_years_2018, jan_2018_wed)
+        self.assertNotEqual(new_years_2024, jan_2024_wed)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tcy.py
+++ b/tests/test_tcy.py
@@ -1,23 +1,18 @@
 import unittest
 import unittest.mock as mock
-from datetime import datetime, timedelta
+from datetime import datetime
 import pandas as pd
 import pytz
-import os
-from watttime import TCYConfig, TCYCalculator
+from pathlib import Path
+from watttime import TCYCalculator
 
 REGION = "CAISO_NORTH"
 
 class TestTCY(unittest.TestCase):
     def setUp(self):
-        self.config = TCYConfig(
+        self.calculator = TCYCalculator(
             region=REGION,
             timezone="America/Los_Angeles"
-        )
-        self.calculator = TCYCalculator(
-            username=os.getenv("WATTTIME_USER"),
-            password=os.getenv("WATTTIME_PASSWORD"),
-            config=self.config
         )
 
     def test_tcy_weekday_weekend_differentiation(self):

--- a/tests/test_tcy.py
+++ b/tests/test_tcy.py
@@ -1,0 +1,75 @@
+import unittest
+import unittest.mock as mock
+from datetime import datetime, timedelta
+import pandas as pd
+import pytz
+import os
+from watttime import TCYConfig, TCYCalculator
+
+REGION = "CAISO_NORTH"
+
+class TestTCY(unittest.TestCase):
+    def setUp(self):
+        self.config = TCYConfig(
+            region=REGION,
+            timezone="America/Los_Angeles"
+        )
+        self.calculator = TCYCalculator(
+            username=os.getenv("WATTTIME_USER"),
+            password=os.getenv("WATTTIME_PASSWORD"),
+            config=self.config
+        )
+
+    def test_tcy_weekday_weekend_differentiation(self):
+        """Test that TCY properly differentiates between weekdays and weekends"""
+        dates = pd.date_range(
+            start='2023-01-01', 
+            end='2023-01-31',
+            freq='H',
+            tz='America/Los_Angeles'
+        )
+        values = [100 if self.calculator._is_weekday(d) else 200 for d in dates]
+        test_data = pd.DataFrame({'value': values}, index=dates)
+
+        ref_table = self.calculator._create_reference_table(test_data)
+
+        weekday_value = ref_table[
+            (ref_table['month'] == 1) & 
+            (ref_table['hour'] == 12) & 
+            (ref_table['is_weekday'] == True)
+        ]['value'].iloc[0]
+        weekend_value = ref_table[
+            (ref_table['month'] == 1) & 
+            (ref_table['hour'] == 12) & 
+            (ref_table['is_weekday'] == False)
+        ]['value'].iloc[0]
+        
+        self.assertEqual(weekday_value, 100)
+        self.assertEqual(weekend_value, 200)
+
+    def test_tcy_new_years_holiday(self):
+        """Test that New Year's Day is treated as a weekend/holiday"""
+        new_years = pd.Timestamp('2024-01-01', tz='America/Los_Angeles')
+        self.assertFalse(self.calculator._is_weekday(new_years))
+        
+        # Test same date but not a holiday
+        regular_day = pd.Timestamp('2024-01-02', tz='America/Los_Angeles')
+        self.assertTrue(self.calculator._is_weekday(regular_day))
+
+    def test_tcy_timezone_handling(self):
+        """Test that timezone conversion works correctly with real data"""
+        historical_data = self.calculator._get_historical_data()
+        
+        # Check historical data timezone
+        self.assertEqual(historical_data.index.tz.zone, "America/Los_Angeles")
+        self.assertTrue('+00:00' not in str(historical_data.index[0]))  # Not UTC
+        self.assertTrue('-08:00' in str(historical_data.index[0]) or '-07:00' in str(historical_data.index[0]))  # Pacific time
+        
+        # Check TCY result timezone
+        tcy = self.calculator.calculate_tcy(2024)
+        self.assertEqual(tcy.index.tz.zone, "America/Los_Angeles")
+        self.assertEqual(str(tcy.index[0])[:4], "2024")  # Starts at beginning of year
+        self.assertTrue('-08:00' in str(tcy.index[0]) or '-07:00' in str(tcy.index[0]))  # Pacific time
+
+if __name__ == "__main__":
+    unittest.main()

--- a/watttime/__init__.py
+++ b/watttime/__init__.py
@@ -1,1 +1,2 @@
 from watttime.api import *
+from .tcy import TCYConfig, TCYCalculator

--- a/watttime/__init__.py
+++ b/watttime/__init__.py
@@ -1,2 +1,2 @@
 from watttime.api import *
-from .tcy import TCYConfig, TCYCalculator
+from watttime.tcy import TCYCalculator

--- a/watttime/tcy.py
+++ b/watttime/tcy.py
@@ -1,0 +1,109 @@
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+import pandas as pd
+import pytz
+from typing import Optional, List
+from .api import WattTimeHistorical
+
+@dataclass
+class TCYConfig:
+    """Configuration for TCY calculation"""
+    region: str
+    timezone: str
+    holidays: Optional[List[str]] = None
+
+class TCYCalculator:
+    """Calculate Typical Carbon Year profiles from historical MOER data using a 3-year lookback period"""
+    
+    def __init__(self, username: str, password: str, config: TCYConfig):
+        self.wt_client = WattTimeHistorical(username, password)
+        self.config = config
+        self.timezone = pytz.timezone(config.timezone)
+        
+        if not config.holidays:
+            self.holidays = [
+                "2023-01-01", "2023-05-29", "2023-07-04", "2023-09-04",
+                "2023-11-23", "2023-12-25",
+                "2024-01-01", "2024-05-27", "2024-07-04", "2024-09-02",
+                "2024-11-28", "2024-12-25"
+            ]
+        else:
+            self.holidays = config.holidays
+
+    def _get_historical_data(self) -> pd.DataFrame:
+        """Fetch 3 years of historical MOER data"""
+        end = datetime.now(pytz.UTC)
+        # Always use exactly 3 years of historical data
+        start = end - timedelta(days=365 * 3)
+        
+        df = self.wt_client.get_historical_pandas(
+            start=start.strftime('%Y-%m-%d %H:%MZ'),
+            end=end.strftime('%Y-%m-%d %H:%MZ'),
+            region=self.config.region,
+            signal_type='co2_moer'
+        )
+        
+        # Set point_time as index and convert timezone
+        df = df.set_index('point_time')
+        df.index = df.index.tz_convert(self.timezone)
+        
+        return df
+    
+    def _is_weekday(self, date: pd.Timestamp) -> bool:
+        """Determine if a given date is a weekday (not weekend or holiday)"""
+        date_str = date.strftime('%Y-%m-%d')
+        return date.weekday() < 5 and date_str not in self.holidays
+
+    def _create_reference_table(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Create reference table of typical values for each month/hour/day type combination"""
+        # Add helper columns
+        df = df.assign(
+            month=df.index.month,
+            hour=df.index.hour,
+            is_weekday=df.index.map(self._is_weekday)
+        )
+        
+        # Group and calculate averages
+        reference = df.groupby(['month', 'hour', 'is_weekday'])['value'].mean().reset_index()
+        return reference
+
+    def _generate_hourly_profile(self, year: int, reference: pd.DataFrame) -> pd.DataFrame:
+        """Generate hourly profile for specified year using reference data"""
+        # Create datetime index for entire year
+        start = pd.Timestamp(year=year, month=1, day=1, tz=self.timezone)
+        end = pd.Timestamp(year=year+1, month=1, day=1, tz=self.timezone)
+        dates = pd.date_range(start=start, end=end, freq='H', inclusive='left')
+        
+        # Create profile DataFrame
+        profile = pd.DataFrame(index=dates)
+        profile['month'] = profile.index.month
+        profile['hour'] = profile.index.hour
+        profile['is_weekday'] = profile.index.map(self._is_weekday)
+        
+        # Merge with reference data to get typical values
+        profile = profile.merge(
+            reference,
+            on=['month', 'hour', 'is_weekday'],
+            how='left'
+        )
+        
+        # Forward fill any missing values
+        profile['value'] = profile['value'].fillna(method='ffill')
+        
+        return profile.set_index(dates)['value']
+
+    def calculate_tcy(self, target_year: int) -> pd.DataFrame:
+        """
+        Calculate Typical Carbon Year profile for the specified year
+        using 3 years of historical data to generate the profile.
+        """
+        # Get historical data (3 years)
+        historical_data = self._get_historical_data()
+        
+        # Create reference table
+        reference_table = self._create_reference_table(historical_data)
+        
+        # Generate hourly profile
+        tcy_profile = self._generate_hourly_profile(target_year, reference_table)
+        
+        return tcy_profile


### PR DESCRIPTION
This PR adds functionality to calculate a Typical Carbon Year (TCY) profile for any given year using 3 years of historical MOER data. 

Changes:
- Add TCY implementation
- Add testing 
- Update documentation

The implementation takes historical MOER data from past 3 years, aggregates by month, hour, and day type, converts timezones, and returns hourly values. 

The tests I wrote pass, and I also tested the implementation manually with my login credentials. 