### PR TITLE
refactor multithreading into WattTimeBase

### DIFF
--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -135,7 +135,7 @@ class TestWattTimeBase(unittest.TestCase):
         self.assertIsInstance(parsed_end, datetime)
         self.assertEqual(parsed_end.tzinfo, UTC)
 
-    @mock.patch("watttime.requests.Session.post", side_effect=mocked_register)
+    @mock.patch("requests.post", side_effect=mocked_register)
     def test_mock_register(self, mock_post):
         resp = self.base.register(email=os.getenv("WATTTIME_EMAIL"))
         self.assertEqual(len(mock_post.call_args_list), 1)

--- a/watttime/api.py
+++ b/watttime/api.py
@@ -258,7 +258,7 @@ class WattTimeBase:
 
         responses = []
         if self.multithreaded:
-            with ThreadPoolExecutor(max_workers=os.cpu_count() * 5) as executor:
+            with ThreadPoolExecutor(max_workers=10) as executor:
                 futures = {
                     executor.submit(
                         self._make_rate_limited_request, url, params


### PR DESCRIPTION
This is a refactor of the multithreading changes introduced in #34 

Notably, we wanted to remove the use of a `MixIn` object. This was achieved by adding new methods to `WattTimeBase` including:
- `_make_rate_limited_request`: this should be used in place of `request.get()` across all child classes. For both single threaded and multithreaded applications, it will ensure that no more than 10 requests per second can be submitted, and if they are, it will sleep (0.1s) until the limit is no longer violated. Significant DRY code was moved into this method to `get`, `raise_for_status()`, raise any exceptions, and print any warnings.
- `_apply_rate_limit` is used by `make_rate_limited_request`. This method checks a class attribute tracking the times of the last submitted requests, and ensures that no more than `self.rate_limit` are submitted per second. This is achieved by sleeping in a singlethreaded context, and using threading.Condition when multithreading to wait the appropriate amount of time. No use of the `threading` module is required at all if `self.multithreaded==False`
- `_fetch_data` will call `_make_rate_limited_request` in a for loop with a list of parameters (e.g. chunks of dates). if multithreading is enabled, then a threadpool executor is used and futures are examined `as_completed()`

Sorry for the messy git history here... I was working with this repo as `upstream` and when I went to push to a new branch (`multithreading-refactor`) it pushed to `main`. I wouldn't think this would be possible due to branch protection rules... I'll look into how to tighten those up. In any case, I reverted the commit on `main`, rebased `main` into this branch and then cherry-picked the commit to show the differences here while maintaining the history. 

