### PR TITLE
Use sessions instead of individual connections

### DIFF
--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -135,7 +135,7 @@ class TestWattTimeBase(unittest.TestCase):
         self.assertIsInstance(parsed_end, datetime)
         self.assertEqual(parsed_end.tzinfo, UTC)
 
-    @mock.patch("requests.post", side_effect=mocked_register)
+    @mock.patch("watttime.requests.Session.post", side_effect=mocked_register)
     def test_mock_register(self, mock_post):
         resp = self.base.register(email=os.getenv("WATTTIME_EMAIL"))
         self.assertEqual(len(mock_post.call_args_list), 1)

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -135,7 +135,7 @@ class TestWattTimeBase(unittest.TestCase):
         self.assertIsInstance(parsed_end, datetime)
         self.assertEqual(parsed_end.tzinfo, UTC)
 
-    @mock.patch("watttime.requests.Session.post", side_effect=mocked_register)
+    @mock.patch("requests.post", side_effect=mocked_register)
     def test_mock_register(self, mock_post):
         resp = self.base.register(email=os.getenv("WATTTIME_EMAIL"))
         self.assertEqual(len(mock_post.call_args_list), 1)

--- a/watttime/api.py
+++ b/watttime/api.py
@@ -258,7 +258,7 @@ class WattTimeBase:
 
         responses = []
         if self.multithreaded:
-            with ThreadPoolExecutor(max_workers=os.cpu_count() * 5) as executor:
+            with ThreadPoolExecutor(max_workers=10) as executor:
                 futures = {
                     executor.submit(
                         self._make_rate_limited_request, url, params

--- a/watttime/api.py
+++ b/watttime/api.py
@@ -47,6 +47,8 @@ class WattTimeBase:
             )  # prevent multiple threads from modifying _last_request_times simultaneously
             self._rate_limit_condition = threading.Condition(self._rate_limit_lock)
 
+        self.session = requests.Session()
+
     def _login(self):
         """
         Login to the WattTime API, which provides a JWT valid for 30 minutes
@@ -56,7 +58,7 @@ class WattTimeBase:
         """
 
         url = f"{self.url_base}/login"
-        rsp = requests.get(
+        rsp = self.session.get(
             url,
             auth=requests.auth.HTTPBasicAuth(self.username, self.password),
             timeout=20,
@@ -147,7 +149,7 @@ class WattTimeBase:
             "org": organization,
         }
 
-        rsp = requests.post(url, json=params, timeout=20)
+        rsp = self.session.post(url, json=params, timeout=20)
         rsp.raise_for_status()
         print(
             f"Successfully registered {self.username}, please check {email} for a verification email"
@@ -202,7 +204,7 @@ class WattTimeBase:
             self._apply_rate_limit(ts)
 
         try:
-            rsp = requests.get(url, headers=self.headers, params=params)
+            rsp = self.session.get(url, headers=self.headers, params=params)
             rsp.raise_for_status()
             j = rsp.json()
         except requests.exceptions.RequestException as e:


### PR DESCRIPTION
Pulling out a non-refactor change from #35 . In some profiling I was seeing new connections caused by repeated calls to `request.get` occasionally hang. 