### PR TITLE
Speed up historical forecast parsing by avoiding pd.json_normalize

### DIFF
--- a/watttime/api.py
+++ b/watttime/api.py
@@ -395,13 +395,16 @@ class WattTimeForecast(WattTimeBase, RateLimitedRequesterMixin):
         Returns:
             pd.DataFrame: A pandas DataFrame containing the parsed historical forecast data.
         """
-        out = pd.DataFrame()
-        for json in json_list:
-            for entry in json.get("data", []):
-                _df = pd.json_normalize(entry, record_path=["forecast"])
-                _df = _df.assign(generated_at=pd.to_datetime(entry["generated_at"]))
-                out = pd.concat([out, _df], ignore_index=True)
-        return out
+        data = []
+        for j in json_list:
+            for gen_at in j["data"]:
+                for point_time in gen_at["forecast"]:
+                    point_time["generated_at"] = gen_at["generated_at"]
+                    data.append(point_time)
+        df = pd.DataFrame.from_records(data)
+        df["point_time"] = pd.to_datetime(df["point_time"])
+        df["generated_at"] = pd.to_datetime(df["generated_at"])
+        return df
 
     def get_forecast_json(
         self,


### PR DESCRIPTION
`pd.json_normalize` is not efficient to use in a loop. When profiling code, calls to `_parse_historical_forecast_json` improved from 10.8s -> 0.38s for 1% of 1 year of forecasts. 