### PR TITLE
Speed up historical forecast parsing by avoiding pd.json_normalize (#38)

### DIFF
--- a/watttime/api.py
+++ b/watttime/api.py
@@ -479,13 +479,16 @@ class WattTimeForecast(WattTimeBase):
         Returns:
             pd.DataFrame: A pandas DataFrame containing the parsed historical forecast data.
         """
-        out = pd.DataFrame()
-        for json in json_list:
-            for entry in json.get("data", []):
-                _df = pd.json_normalize(entry, record_path=["forecast"])
-                _df = _df.assign(generated_at=pd.to_datetime(entry["generated_at"]))
-                out = pd.concat([out, _df], ignore_index=True)
-        return out
+        data = []
+        for j in json_list:
+            for gen_at in j["data"]:
+                for point_time in gen_at["forecast"]:
+                    point_time["generated_at"] = gen_at["generated_at"]
+                    data.append(point_time)
+        df = pd.DataFrame.from_records(data)
+        df["point_time"] = pd.to_datetime(df["point_time"])
+        df["generated_at"] = pd.to_datetime(df["generated_at"])
+        return df
 
     def get_forecast_json(
         self,


### PR DESCRIPTION
# What
Remove the use of json.normalize within a for loop.

# Why
It is 10x slower than direct assignment on each item in the json.

# How
Use direct assignment within multiple for loops.
This change was successfully tested in #38. This change is also currently is passing tests on #42 which only has one other unrelated change. 