### PR TITLE
trigger PR tests with main branch

### DIFF
--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -233,6 +233,21 @@ class TestWattTimeHistorical(unittest.TestCase):
         )
 
 
+class TestWattTimeHistoricalMultiThreaded(unittest.TestCase):
+
+    def setUp(self):
+        self.historical = WattTimeHistorical(multithreaded=True)
+
+    def test_get_historical_jsons_3_months_multithreaded(self):
+        start = "2022-01-01 00:00Z"
+        end = "2022-12-31 00:00Z"
+        jsons = self.historical.get_historical_jsons(start, end, REGION)
+
+        self.assertIsInstance(jsons, list)
+        self.assertGreaterEqual(len(jsons), 1)
+        self.assertIsInstance(jsons[0], dict)
+
+
 class TestWattTimeMyAccess(unittest.TestCase):
     def setUp(self):
         self.access = WattTimeMyAccess()
@@ -294,7 +309,6 @@ class TestWattTimeMyAccess(unittest.TestCase):
 class TestWattTimeForecast(unittest.TestCase):
     def setUp(self):
         self.forecast = WattTimeForecast()
-        self.forecast_mt = WattTimeForecast(multithreaded=True)
 
     def test_get_current_json(self):
         json = self.forecast.get_forecast_json(region=REGION)
@@ -316,18 +330,6 @@ class TestWattTimeForecast(unittest.TestCase):
         start = "2024-01-01 00:00Z"
         end = "2024-01-07 00:00Z"
         json_list = self.forecast.get_historical_forecast_json(
-            start, end, region=REGION
-        )
-        first_json = json_list[0]
-        self.assertIsInstance(json_list, list)
-        self.assertIn("meta", first_json)
-        self.assertEqual(len(first_json["data"]), 288)
-        self.assertIn("generated_at", first_json["data"][0])
-
-    def test_historical_forecast_jsons_multithreaded(self):
-        start = "2024-01-01 00:00Z"
-        end = "2024-01-30 00:00Z"
-        json_list = self.forecast_mt.get_historical_forecast_json(
             start, end, region=REGION
         )
         first_json = json_list[0]
@@ -400,6 +402,24 @@ class TestWattTimeForecast(unittest.TestCase):
         self.assertIn("meta", json3)
         self.assertEqual(len(json3["data"]), 864)
         self.assertIn("point_time", json3["data"][0])
+
+
+class TestWattTimeForecastMultithreaded(unittest.TestCase):
+
+    def setUp(self):
+        self.forecast = WattTimeForecast(multithreaded=True)
+
+    def test_historical_forecast_jsons_multithreaded(self):
+        start = "2024-01-01 00:00Z"
+        end = "2024-01-30 00:00Z"
+        json_list = self.forecast.get_historical_forecast_json(
+            start, end, region=REGION
+        )
+        first_json = json_list[0]
+        self.assertIsInstance(json_list, list)
+        self.assertIn("meta", first_json)
+        self.assertEqual(len(first_json["data"]), 288)
+        self.assertIn("generated_at", first_json["data"][0])
 
 
 class TestWattTimeMaps(unittest.TestCase):

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -49,6 +49,9 @@ class TestWattTimeBase(unittest.TestCase):
     def setUp(self):
         self.base = WattTimeBase()
 
+    def tearDown(self):
+        self.base.session.close()
+
     def test_login_with_real_api(self):
         self.base._login()
         assert self.base.token is not None
@@ -129,6 +132,9 @@ class TestWattTimeBase(unittest.TestCase):
 class TestWattTimeHistorical(unittest.TestCase):
     def setUp(self):
         self.historical = WattTimeHistorical()
+
+    def tearDown(self):
+        self.historical.session.close()
 
     def test_get_historical_jsons_3_months(self):
         start = "2022-01-01 00:00Z"
@@ -238,6 +244,9 @@ class TestWattTimeHistoricalMultiThreaded(unittest.TestCase):
     def setUp(self):
         self.historical = WattTimeHistorical(multithreaded=True)
 
+    def tearDown(self):
+        self.historical.session.close()
+
     def test_get_historical_jsons_3_months_multithreaded(self):
         start = "2022-01-01 00:00Z"
         end = "2022-12-31 00:00Z"
@@ -251,6 +260,9 @@ class TestWattTimeHistoricalMultiThreaded(unittest.TestCase):
 class TestWattTimeMyAccess(unittest.TestCase):
     def setUp(self):
         self.access = WattTimeMyAccess()
+
+    def tearDown(self):
+        self.access.session.close()
 
     def test_access_json_structure(self):
         json = self.access.get_access_json()
@@ -309,6 +321,9 @@ class TestWattTimeMyAccess(unittest.TestCase):
 class TestWattTimeForecast(unittest.TestCase):
     def setUp(self):
         self.forecast = WattTimeForecast()
+
+    def tearDown(self):
+        self.forecast.session.close()
 
     def test_get_current_json(self):
         json = self.forecast.get_forecast_json(region=REGION)
@@ -409,6 +424,9 @@ class TestWattTimeForecastMultithreaded(unittest.TestCase):
     def setUp(self):
         self.forecast = WattTimeForecast(multithreaded=True)
 
+    def tearDown(self):
+        self.forecast.session.close()
+
     def test_historical_forecast_jsons_multithreaded(self):
         start = "2024-01-01 00:00Z"
         end = "2024-01-30 00:00Z"
@@ -425,6 +443,10 @@ class TestWattTimeForecastMultithreaded(unittest.TestCase):
 class TestWattTimeMaps(unittest.TestCase):
     def setUp(self):
         self.maps = WattTimeMaps()
+
+    def tearDown(self):
+        self.maps.session.close()
+        self.myaccess.session.close()
 
     def test_get_maps_json_moer(self):
         moer = self.maps.get_maps_json(signal_type="co2_moer")

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -47,7 +47,7 @@ def mocked_register(*args, **kwargs):
 
 class TestWattTimeBase(unittest.TestCase):
     def setUp(self):
-        self.base = WattTimeBase()
+        self.base = WattTimeBase(rate_limit=2)  # rate limit is used by tests
 
     def tearDown(self):
         self.base.session.close()

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -123,7 +123,7 @@ class TestWattTimeBase(unittest.TestCase):
         self.assertIsInstance(parsed_end, datetime)
         self.assertEqual(parsed_end.tzinfo, UTC)
 
-    @mock.patch("requests.post", side_effect=mocked_register)
+    @mock.patch("watttime.requests.Session.post", side_effect=mocked_register)
     def test_mock_register(self, mock_post):
         resp = self.base.register(email=os.getenv("WATTTIME_EMAIL"))
         self.assertEqual(len(mock_post.call_args_list), 1)


### PR DESCRIPTION
# What
Fix widespread failing tests.
# Why
We cannot reliable tests other PRs since tests are failing intermittently on multiple PRs.
# How
From @sam-watttime:
def setUp gets called for every test, so reduce the number of objects in there as each object was creating a session.
Also include def tearDown methods to close sessions when each test finishes so that tcp sockets don't stay open
Lastly, a pointer for a mocked session was incorrect, this PR fixes that "400" failure
