### PR TITLE
track _last_request_meta in request method

### DIFF
--- a/watttime/api.py
+++ b/watttime/api.py
@@ -215,6 +215,8 @@ class WattTimeBase:
         if j.get("meta", {}).get("warnings"):
             print("Warnings Returned: %s | Response: %s", params, j["meta"])
 
+        self._last_request_meta = j.get("meta", {})
+
         return j
 
     def _apply_rate_limit(self, ts: float):


### PR DESCRIPTION
# What
Stores the API meta field as an attribute in the watttime base class for use downstream.

# Why
A solution to get the last model date for offline use.

# How
Store a suggested private attribute for now, e.g. self._last_request_meta. We want to discourage use of this variable since it only captures the meta from the last request and may not be representative of all requests.