### PR TITLE
Moer forecast joins for analyses

### DIFF
--- a/tests/test_api_joins.py
+++ b/tests/test_api_joins.py
@@ -1,0 +1,87 @@
+import unittest
+from dateutil.parser import parse
+
+from watttime import WattTimeAnalysisData as WattTimeData
+
+import pandas as pd
+
+
+REGION = "CAISO_NORTH"
+
+
+class TestAnalysisDataHandler(unittest.TestCase):
+    def test_get_moers(self):
+        dh = WattTimeData(
+            region=REGION,
+            eval_start=parse("2024-01-01 00:00Z"),
+            eval_end=parse("2024-01-01 23:59Z"),
+            forecast_max_horizon=0,
+        )
+        assert isinstance(dh.moers, pd.DataFrame)
+        assert all(dh.moers.columns == ["signal_value"])
+        assert dh.moers.index.name == "point_time"
+        assert len(dh.moers) == 24 * 12
+
+        dh = WattTimeData(
+            region=REGION,
+            eval_start=parse("2024-01-01 00:00Z"),
+            eval_end=parse("2024-01-01 23:59Z"),
+            forecast_max_horizon=60 * 24,
+        )
+        assert len(dh.moers) == (12 * 24) * 2  # also gets through forecast max horizon
+
+    def test_get_forecasts(self):
+        dh = WattTimeData(
+            region=REGION,
+            eval_start=parse("2024-01-01 00:00Z"),
+            eval_end=parse("2024-01-01 23:59Z"),
+        )
+        assert isinstance(dh.forecasts, pd.DataFrame)
+        assert all(
+            dh.forecasts.columns
+            == ["point_time", "predicted_value", "generated_at", "horizon_mins"]
+        )
+        assert len(dh.forecasts) == (12 * 24) * (12 * 24)
+
+    def test_forecast_v_moer(self):
+        dh = WattTimeData(
+            region=REGION,
+            eval_start=parse("2024-01-01 00:00Z"),
+            eval_end=parse("2024-01-01 23:59Z"),
+        )
+        assert isinstance(dh.forecast_v_moer, pd.DataFrame)
+        assert all(
+            dh.forecast_v_moer.columns
+            == [
+                "predicted_value",
+                "horizon_mins",
+                "signal_value",
+            ]
+        )
+        assert len(dh.forecast_v_moer) == (12 * 24) * (12 * 24)
+        assert sum(dh.forecast_v_moer.isna()["signal_value"]) == 0
+        assert sum(dh.forecast_v_moer.isna()["predicted_value"]) == 0
+
+    def test_forecast_v_moer_sampled(self):
+        # Sample 100%
+        dh = WattTimeData(
+            region=REGION,
+            eval_start=parse("2024-01-01 00:00Z"),
+            eval_end=parse("2024-01-02 23:59Z"),
+            forecast_sample_perc=1.0,
+        )
+        assert len(dh.eval_days) == 2
+        assert len(dh.sample_days) == 2
+        assert len(set(dh.forecasts["generated_at"].dt.date)) == 2
+
+        # Sample 50%
+        dh = WattTimeData(
+            region=REGION,
+            eval_start=parse("2024-01-01 00:00Z"),
+            eval_end=parse("2024-01-02 23:59Z"),
+            forecast_sample_perc=0.5,
+        )
+        assert len(dh.eval_days) == 2
+        assert len(dh.sample_days) == 1
+
+        assert len(set(dh.forecasts["generated_at"].dt.date)) == 1

--- a/watttime/__init__.py
+++ b/watttime/__init__.py
@@ -1,2 +1,3 @@
 from watttime.api import *
+from watttime.api_joins import WattTimeAnalysisData
 from watttime.tcy import TCYCalculator

--- a/watttime/api_joins.py
+++ b/watttime/api_joins.py
@@ -1,0 +1,120 @@
+from typing import Optional, Union, Literal
+from datetime import datetime
+import random
+import math
+from dateutil.parser import parse
+from functools import cached_property
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+from .api import WattTimeHistorical, WattTimeForecast
+
+
+@dataclass
+class WattTimeAnalysisData:
+    """
+    This dataclass performs ETL on WattTime signals including
+    co2_moer, co2_health_damages, and more. Forecasts of these underlying
+    signals are also loaded and merged with the signal for analysis.
+
+    The signal, its forecast, and the merged dataframe are lazily loaded when needed.
+
+    Args:
+        region (str): A single watttime region abbreviation
+        model_date (str | None): A string representing a released model,
+                                 if None, will default to latest provided through API
+        signal_type (str): Such as `co2_moer`, `co2_aoer`, `co2_health_damages`,
+        eval_start (str or datetime): The date to begin pulling signal data for analysis
+        eval_end (str or datetime): The date to stop pulling signal data for analysis
+        forecast_sample_perc (float): A percentage of days of forecasts to sample in
+        order to speed up data retrieval and analysis (between eval_start and eval_end).
+        A value of 1.0 will get all forecasts between eval_start and eval_end.
+        forecast_max_horizon (int): The maximum forecast horizon to pull in minutes
+        wt_forecast (WattTimeForecast): A WattTimeForecast API accessor class
+            may be passed in if you wish to handle login variables or other parameters.
+            Otherwise, credentials are loaded from the environment variables.
+        wt_hist (WattTimeHistorical): A WattTimeHistorical API accessor class
+            may be passed in if you wish to handle login variables or other parameters.
+            Otherwise, credentials are loaded from the environment variables.
+    """
+
+    region: str
+    eval_start: Union[datetime, str]
+    eval_end: Union[datetime, str]
+    forecast_sample_perc: float = 1.0
+    forecast_sample_seed: int = 42
+    forecast_max_horizon: int = 60 * 24
+    signal_type: Literal["co2_moer", "co2_aoer", "health_damage"] = ("co2_moer",)
+    model_date: Optional[str] = None  # Default to latest provided through the API
+    wt_forecast: Optional[WattTimeForecast] = WattTimeForecast(multithreaded=True)
+    wt_hist: Optional[WattTimeHistorical] = WattTimeHistorical()
+
+    def __post_init__(self):
+        self.region = self.region.upper()
+
+        if isinstance(self.eval_start, str):
+            self.eval_start = parse(self.eval_start)
+        if isinstance(self.eval_end, str):
+            self.eval_end = parse(self.eval_end)
+        self.eval_days = list(
+            pd.date_range(start=self.eval_start, end=self.eval_end, freq="1D")
+        )
+
+        if self.forecast_sample_perc >= 1.0:
+            self.sample_days = self.eval_days
+        else:
+            n_sample_days = round(len(self.eval_days) * self.forecast_sample_perc)
+            random.seed(self.forecast_sample_seed)
+            self.sample_days = random.sample(self.eval_days, n_sample_days)
+
+    @cached_property
+    def moers(self) -> pd.DataFrame:
+        moers = (
+            self.wt_hist.get_historical_pandas(
+                start=self.eval_start,
+                # When merging into forecasts, get true moers through the last horizon
+                end=self.eval_end + pd.Timedelta(minutes=self.forecast_max_horizon),
+                region=self.region,
+                signal_type=self.signal_type,
+                model=self.model_date,
+            )
+            .rename(columns={"value": "signal_value"})
+            .set_index("point_time", drop=True)
+        )
+
+        self.returned_meta = self.wt_hist._last_request_meta
+        self.returned_hist_model_date = self.wt_hist._last_request_meta["model"]["date"]
+        return moers
+
+    @cached_property
+    def forecasts(self) -> pd.DataFrame:
+
+        forecasts = self.wt_forecast.get_historical_forecast_pandas_list(
+            list_of_dates=self.sample_days,
+            region=self.region,
+            signal_type=self.signal_type,
+            model=self.model_date,
+            horizon_hours=math.ceil(self.forecast_max_horizon / 60),
+        )
+
+        forecasts["point_time"] = pd.to_datetime(forecasts["point_time"])
+        forecasts["horizon_mins"] = (
+            forecasts["point_time"] - forecasts["generated_at"]
+        ).dt.total_seconds() / 60
+        forecasts.rename({"value": "predicted_value"}, axis="columns", inplace=True)
+        self.returned_meta = self.wt_forecast._last_request_meta
+        self.returned_forecast_model_date = self.wt_forecast._last_request_meta[
+            "model"
+        ]["date"]
+        return forecasts
+
+    @cached_property
+    def forecast_v_moer(self) -> pd.DataFrame:
+        return self.forecasts.merge(
+            self.moers,
+            how="inner",
+            left_on="point_time",
+            right_on="point_time",
+        ).set_index(["generated_at", "point_time"], drop=True)


### PR DESCRIPTION
# What
Add an object that returns WattTime forecasts in a dataframe such that each rows contains both a forecast and the actual moer at the same time.

# Why
To support analyses of WattTime forecasts performance.

# How 
Use the existing api historical and forecast objects to return all necessary data into a data class. The necessary data is moers, forecasts, and forecast_v_moers (i.e. the merged dataframe).