### PR TITLE
Increase Testing reliability

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,4 +43,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest
+        pytest --reruns 2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
+        pip install flake8 pytest pytest-rerunfailures
         pip install .
     - name: Lint with flake8
       run: |

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -256,7 +256,7 @@ class TestWattTimeHistorical(unittest.TestCase):
 class TestWattTimeHistoricalMultiThreaded(unittest.TestCase):
 
     def setUp(self):
-        self.historical = WattTimeHistorical(multithreaded=True, rate_limit=5)
+        self.historical = WattTimeHistorical(multithreaded=True, rate_limit=1)
 
     def tearDown(self):
         self.historical.session.close()

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -335,7 +335,7 @@ class TestWattTimeMyAccess(unittest.TestCase):
 
 class TestWattTimeForecast(unittest.TestCase):
     def setUp(self):
-        self.forecast = WattTimeForecast(rate_limit=1)
+        self.forecast = WattTimeForecast(rate_limit=1, multithreaded=False)
 
     def tearDown(self):
         self.forecast.session.close()
@@ -436,7 +436,9 @@ class TestWattTimeForecast(unittest.TestCase):
 
 class TestWattTimeForecastMultithreaded(unittest.TestCase):
     def setUp(self):
-        self.forecast = WattTimeForecast(multithreaded=True, rate_limit=1)
+        self.forecast = WattTimeForecast(
+            multithreaded=True, rate_limit=1, worker_count=2
+        )
 
     def tearDown(self):
         self.forecast.session.close()

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -145,7 +145,7 @@ class TestWattTimeBase(unittest.TestCase):
 
 class TestWattTimeHistorical(unittest.TestCase):
     def setUp(self):
-        self.historical = WattTimeHistorical(rate_limit=5)
+        self.historical = WattTimeHistorical(rate_limit=1)
 
     def tearDown(self):
         self.historical.session.close()
@@ -256,7 +256,7 @@ class TestWattTimeHistorical(unittest.TestCase):
 class TestWattTimeHistoricalMultiThreaded(unittest.TestCase):
     def setUp(self):
         self.historical = WattTimeHistorical(
-            multithreaded=True, rate_limit=5, worker_count=2
+            multithreaded=True, rate_limit=1, worker_count=2
         )
 
     def tearDown(self):
@@ -336,7 +336,7 @@ class TestWattTimeMyAccess(unittest.TestCase):
 
 class TestWattTimeForecast(unittest.TestCase):
     def setUp(self):
-        self.forecast = WattTimeForecast(rate_limit=5)
+        self.forecast = WattTimeForecast(rate_limit=1)
 
     def tearDown(self):
         self.forecast.session.close()
@@ -437,7 +437,7 @@ class TestWattTimeForecast(unittest.TestCase):
 
 class TestWattTimeForecastMultithreaded(unittest.TestCase):
     def setUp(self):
-        self.forecast = WattTimeForecast(multithreaded=True, rate_limit=5)
+        self.forecast = WattTimeForecast(multithreaded=True, rate_limit=1)
 
     def tearDown(self):
         self.forecast.session.close()

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -262,7 +262,6 @@ class TestWattTimeHistoricalMultiThreaded(unittest.TestCase):
     def tearDown(self):
         self.historical.session.close()
 
-    # @pytest.mark.skip("TODO - flaky")
     def test_get_historical_jsons_3_months_multithreaded(self):
         start = "2022-01-01 00:00Z"
         end = "2022-03-31 00:00Z"

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -261,7 +261,7 @@ class TestWattTimeHistoricalMultiThreaded(unittest.TestCase):
     def tearDown(self):
         self.historical.session.close()
 
-    @pytest.mark.skip("TODO - flaky")
+    # @pytest.mark.skip("TODO - flaky")
     def test_get_historical_jsons_3_months_multithreaded(self):
         start = "2022-01-01 00:00Z"
         end = "2022-03-31 00:00Z"

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -254,9 +254,10 @@ class TestWattTimeHistorical(unittest.TestCase):
 
 
 class TestWattTimeHistoricalMultiThreaded(unittest.TestCase):
-
     def setUp(self):
-        self.historical = WattTimeHistorical(multithreaded=True, rate_limit=1)
+        self.historical = WattTimeHistorical(
+            multithreaded=True, rate_limit=5, worker_count=2
+        )
 
     def tearDown(self):
         self.historical.session.close()
@@ -435,7 +436,6 @@ class TestWattTimeForecast(unittest.TestCase):
 
 
 class TestWattTimeForecastMultithreaded(unittest.TestCase):
-
     def setUp(self):
         self.forecast = WattTimeForecast(multithreaded=True, rate_limit=5)
 

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -263,8 +263,8 @@ class TestWattTimeHistoricalMultiThreaded(unittest.TestCase):
         self.historical.session.close()
 
     def test_get_historical_jsons_3_months_multithreaded(self):
-        start = "2022-01-01 00:00Z"
-        end = "2022-03-31 00:00Z"
+        start = "2024-01-01 00:00Z"
+        end = "2024-03-31 00:00Z"
         jsons = self.historical.get_historical_jsons(start, end, REGION)
 
         self.assertIsInstance(jsons, list)

--- a/watttime/api.py
+++ b/watttime/api.py
@@ -61,7 +61,7 @@ class WattTimeBase:
         rsp = self.session.get(
             url,
             auth=requests.auth.HTTPBasicAuth(self.username, self.password),
-            timeout=20,
+            timeout=(10, 60),
         )
         rsp.raise_for_status()
         self.token = rsp.json().get("token", None)
@@ -149,7 +149,7 @@ class WattTimeBase:
             "org": organization,
         }
 
-        rsp = self.session.post(url, json=params, timeout=20)
+        rsp = self.session.post(url, json=params, timeout=(10, 60))
         rsp.raise_for_status()
         print(
             f"Successfully registered {self.username}, please check {email} for a verification email"

--- a/watttime/api.py
+++ b/watttime/api.py
@@ -190,6 +190,9 @@ class WattTimeBase:
         """
         Makes a single API request while respecting the rate limit.
         """
+        
+        # should already be logged in -- keeping incase long running chunked request surpasses
+        # token timeout
         if not self._is_token_valid() or not self.headers:
             self._login()
 
@@ -256,6 +259,10 @@ class WattTimeBase:
         This class is suited for making a series of requests in a for loop, with
         varying `param_chunks`.
         """
+        
+        # first try to login before beginning multithreading
+        if not self._is_token_valid() or not self.headers:
+            self._login()
 
         if isinstance(param_chunks, dict):
             param_chunks = [param_chunks]

--- a/watttime/api.py
+++ b/watttime/api.py
@@ -31,6 +31,10 @@ class WattTimeBase:
         Parameters:
             username (Optional[str]): The username to use for authentication. If not provided, the value will be retrieved from the environment variable "WATTTIME_USER".
             password (Optional[str]): The password to use for authentication. If not provided, the value will be retrieved from the environment variable "WATTTIME_PASSWORD".
+            multithreaded (bool): Whether to use multithreading for requests. Default is False.
+            rate_limit (int): The maximum number of requests to make per second. Default is 10 as this algins well with WattTime's API rate limiting policy.
+            worker_count (int): The number of worker threads to use for multithreading. Default is min(10, (os.cpu_count() or 1) * 2).
+
         """
         self.username = username or os.getenv("WATTTIME_USER")
         self.password = password or os.getenv("WATTTIME_PASSWORD")


### PR DESCRIPTION
I believe #2d538 (reduce multithread worrkers) is the most impactful change here, followed by #95c155a (enforce a lower rate limit in tests in case tests are running simultaneous). 

The other changes should also increase reliability:
- login before spawning threads to avoid a stampede of login requests
- separate our timeout into connect and read components
-  rerun pytests 2 times if one fails (a TCY test fails intermittently with subtle differences between float math)

