### PR TITLE
4) get login from env every time

### DIFF
--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -144,6 +144,16 @@ class TestWattTimeBase(unittest.TestCase):
         resp = self.base.register(email=os.getenv("WATTTIME_EMAIL"))
         self.assertEqual(len(mock_post.call_args_list), 1)
 
+    @patch.dict(os.environ, {"WATTTIME_USER": "env_user"}, clear=False)
+    @patch("watttime.api.LOG.warning")
+    def test_username_arg_warns_when_env_user_already_set(self, mock_warning):
+        base = WattTimeBase(username="arg_user")
+        self.assertEqual(os.getenv("WATTTIME_USER"), "arg_user")
+        mock_warning.assert_called_once_with(
+            "Both a username argument and WATTTIME_USER are set; using the username argument value."
+        )
+        base.session.close()
+
 
 class TestWattTimeHistorical(unittest.TestCase):
     def setUp(self):

--- a/watttime/api.py
+++ b/watttime/api.py
@@ -75,6 +75,11 @@ class WattTimeBase:
 
         """
 
+        if username and os.getenv("WATTTIME_USER") is not None:
+            LOG.warning(
+                "Both a username argument and WATTTIME_USER are set; using the username argument value."
+            )
+
         if username:
             os.environ["WATTTIME_USER"] = username
         if password:

--- a/watttime/api.py
+++ b/watttime/api.py
@@ -74,8 +74,12 @@ class WattTimeBase:
             worker_count (int): The number of worker threads to use for multithreading. Default is min(10, (os.cpu_count() or 1) * 2).
 
         """
-        self.username = username or os.getenv("WATTTIME_USER")
-        self.password = password or os.getenv("WATTTIME_PASSWORD")
+
+        if username:
+            os.environ["WATTTIME_USER"] = username
+        if password:
+            os.environ["WATTTIME_PASSWORD"] = password
+
         self.token = None
         self.headers = None
         self.token_valid_until = None
@@ -115,7 +119,7 @@ class WattTimeBase:
         url = f"{self.url_base}/login"
         rsp = self.session.get(
             url,
-            auth=requests.auth.HTTPBasicAuth(self.username, self.password),
+            auth=requests.auth.HTTPBasicAuth(os.getenv("WATTTIME_USER"), os.getenv("WATTTIME_PASSWORD")),
             timeout=(10, 60),
         )
         rsp.raise_for_status()
@@ -198,8 +202,8 @@ class WattTimeBase:
 
         url = f"{self.url_base}/register"
         params = {
-            "username": self.username,
-            "password": self.password,
+            "username": os.getenv("WATTTIME_USER"),
+            "password": os.getenv("WATTTIME_PASSWORD"),
             "email": email,
             "org": organization,
         }
@@ -207,7 +211,7 @@ class WattTimeBase:
         rsp = self.session.post(url, json=params, timeout=(10, 60))
         rsp.raise_for_status()
         LOG.info(
-            f"Successfully registered {self.username}, please check {email} for a verification email"
+            f"Successfully registered {os.getenv('WATTTIME_USER')}, please check {email} for a verification email"
         )
 
     @cache


### PR DESCRIPTION
# What
Read login credential from os.environ every time

# Why
This will reduce the surface area of credentials to only the process's os.evniron

# How
Read directly from os.enrion every time a credential is necessary, e.g. the first login or to refresh a token.