### PR TITLE
2) Retry 500s

### DIFF
--- a/watttime/api.py
+++ b/watttime/api.py
@@ -9,6 +9,8 @@ from functools import cache
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from urllib3.util.retry import Retry
+from requests.adapters import HTTPAdapter
 
 import pandas as pd
 import requests
@@ -90,7 +92,17 @@ class WattTimeBase:
             )  # prevent multiple threads from modifying _last_request_times simultaneously
             self._rate_limit_condition = threading.Condition(self._rate_limit_lock)
 
+        retry_strategy = Retry(
+            total=3,
+            status_forcelist=[500, 502, 503, 504],
+            backoff_factor=1,
+            raise_on_status=False,
+        )
+
+        adapter = HTTPAdapter(max_retries=retry_strategy)
         self.session = requests.Session()
+        self.session.mount("http://", adapter)
+        self.session.mount("https://", adapter)
 
     def _login(self):
         """


### PR DESCRIPTION
# What
Make the request session more robust to intermittent issues.

# Why
So that users of the client, e.g. a "hungry analyst", can more easily retrieve data despite intermittent 500 issues

# How
Introduce a Retry class to the sessions that checks for 500, 502, 503, and 504 and retries 3 times.