### PR TITLE
1) Add WattTimeAPIWarning class and logging infrastructure

### DIFF
--- a/watttime/api.py
+++ b/watttime/api.py
@@ -2,6 +2,7 @@ import os
 import time
 import threading
 import time
+import logging
 from datetime import date, datetime, timedelta, time as dt_time
 from collections import defaultdict
 from functools import cache
@@ -13,6 +14,40 @@ import pandas as pd
 import requests
 from dateutil.parser import parse
 from pytz import UTC
+
+
+class WattTimeAPIWarning:
+    def __init__(self, url: str, params: Dict[str, Any], warning_message: str):
+        self.url = url
+        self.params = params
+        self.warning_message = warning_message
+
+    def __repr__(self):
+        return f"<WattTimeAPIWarning url={self.url}, params={self.params}, warning={self.warning_message}>\n"
+
+    def to_dict(self) -> Dict[str, Any]:
+        def stringify(value: Any) -> Any:
+            if isinstance(value, datetime):
+                return value.isoformat()
+            return value
+
+        return {
+            "url": self.url,
+            "params": {k: stringify(v) for k, v in self.params.items()},
+            "warning_message": self.warning_message,
+        }
+
+
+def get_log():
+    logging.basicConfig(
+        format="%(asctime)s [%(levelname)-1s]  " "%(message)s",
+        level=logging.INFO,
+        handlers=[logging.StreamHandler()],
+    )
+    return logging.getLogger()
+
+
+LOG = get_log()
 
 
 class WattTimeBase:
@@ -47,6 +82,7 @@ class WattTimeBase:
         self.rate_limit = rate_limit
         self._last_request_times = []
         self.worker_count = worker_count
+        self.raised_warnings: List[WattTimeAPIWarning] = []
 
         if self.multithreaded:
             self._rate_limit_lock = (
@@ -158,7 +194,7 @@ class WattTimeBase:
 
         rsp = self.session.post(url, json=params, timeout=(10, 60))
         rsp.raise_for_status()
-        print(
+        LOG.info(
             f"Successfully registered {self.username}, please check {email} for a verification email"
         )
 
@@ -222,10 +258,19 @@ class WattTimeBase:
                 f"API Request Failed: {e}\nURL: {url}\nParams: {params}"
             ) from e
 
-        if j.get("meta", {}).get("warnings"):
-            print("Warnings Returned: %s | Response: %s", params, j["meta"])
+        meta = j.get("meta", {})
+        warnings = meta.get("warnings")
+        if warnings:
+            for warning_message in warnings:
+                warning = WattTimeAPIWarning(
+                    url=url, params=params, warning_message=warning_message
+                )
+                self.raised_warnings.append(warning)
+                LOG.warning(
+                    f"API Warning: {warning_message} | URL: {url} | Params: {params}"
+                )
 
-        self._last_request_meta = j.get("meta", {})
+        self._last_request_meta = meta
 
         return j
 
@@ -409,7 +454,7 @@ class WattTimeHistorical(WattTimeBase):
         start, end = self._parse_dates(start, end)
         fp = out_dir / f"{region}_{signal_type}_{start.date()}_{end.date()}.csv"
         df.to_csv(fp, index=False)
-        print(f"file written to {fp}")
+        LOG.info(f"file written to {fp}")
 
 
 class WattTimeMyAccess(WattTimeBase):
@@ -712,7 +757,6 @@ class WattTimeMaps(WattTimeBase):
 
 
 class WattTimeMarginalFuelMix(WattTimeBase):
-
     def get_fuel_mix_jsons(
         self,
         start: Union[str, datetime],
@@ -734,7 +778,7 @@ class WattTimeMarginalFuelMix(WattTimeBase):
         chunks = self._get_chunks(start, end, chunk_size=timedelta(days=30))
 
         # No model will default to the most recent model version available
-        if model:
+        if model is not None:
             params["model"] = model
 
         param_chunks = [{**params, "start": c[0], "end": c[1]} for c in chunks]


### PR DESCRIPTION
# What
A clean history of the relevant changes in #62, without any other changes

# Why 
We track raised warnings to be included in the meta section of report cards.

# How
- Add WattTimeAPIWarning class for structured warning tracking
- Add logging module (get_log, LOG) replacing print() calls
- Collect warnings in self.raised_warnings list
- Iterate meta.warnings and create WattTimeAPIWarning per warning
- Replace print() with LOG.info() in register() and get_historical_csv()
- Fix model check: if model -> if model is not None