### PR TITLE
3) Add test validating my-access regions match geojson maps, geojson is CCW

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,8 +33,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest pytest-rerunfailures
-        pip install .
+        pip install .[testing]
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/setup.py
+++ b/setup.py
@@ -9,4 +9,5 @@ setup(
     packages=["watttime"],
     python_requires=">=3.8",
     install_requires=["requests", "pandas>1.0.0", "holidays", "python-dateutil", "pytz"],
+    extras_require={"testing": ["pytest", "pytest-rerunfailures", "flake8", "shapely"]},
 )

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -15,6 +15,7 @@ from watttime import (
 )
 from pathlib import Path
 import pytest
+from shapely.geometry import shape, Polygon, MultiPolygon
 
 import pandas as pd
 
@@ -464,9 +465,11 @@ class TestWattTimeForecastMultithreaded(unittest.TestCase):
 class TestWattTimeMaps(unittest.TestCase):
     def setUp(self):
         self.maps = WattTimeMaps()
+        self.myaccess = WattTimeMyAccess()
 
     def tearDown(self):
         self.maps.session.close()
+        self.myaccess.session.close()
 
     def test_get_maps_json_moer(self):
         moer = self.maps.get_maps_json(signal_type="co2_moer")
@@ -502,6 +505,39 @@ class TestWattTimeMaps(unittest.TestCase):
         self.assertEqual(region["region"], "PSCO")
         self.assertEqual(region["region_full_name"], "Public Service Co of Colorado")
         self.assertEqual(region["signal_type"], "co2_moer")
+
+    def test_my_access_in_geojson(self):
+        access = self.myaccess.get_access_pandas()
+        for signal_type in ["co2_moer", "co2_aoer", "health_damage"]:
+            access_regions = access.loc[
+                access["signal_type"] == signal_type, "region"
+            ].unique()
+            maps = self.maps.get_maps_json(signal_type=signal_type)
+            maps_regions = [i["properties"]["region"] for i in maps["features"]]
+
+            assert (
+                set(access_regions) - set(maps_regions) == set()
+            ), f"Missing regions in geojson for {signal_type}: {set(access_regions) - set(maps_regions)}"
+            assert (
+                set(maps_regions) - set(access_regions) == set()
+            ), f"Extra regions in geojson for {signal_type}: {set(maps_regions) - set(access_regions)}"
+
+    def test_ccw(self):
+        moer = self.maps.get_maps_json(signal_type="co2_moer")
+
+        def _is_ccw(geometry):
+            if isinstance(geometry, Polygon):
+                return geometry.exterior.is_ccw
+            elif isinstance(geometry, MultiPolygon):
+                return all(poly.exterior.is_ccw for poly in geometry.geoms)
+            return True
+
+        bad = [
+            f["properties"]["region_full_name"]
+            for f in moer["features"]
+            if not _is_ccw(shape(f["geometry"]))
+        ]
+        assert len(bad) == 0, f"Non-CCW geometries: {bad}"
 
 
 class TestWattTimeMarginalFuelMix(unittest.TestCase):


### PR DESCRIPTION
# What
Adds two tests looking at maps:
1) `test_my_access_in_geojson`: this ensures that regions listed in my-access are also listed in map geojson entries.
3) `test_ccw`:  this ensures that all geometries in the geojson are counter clockwise

# Why
These tests help ensure that our geojsons have not become corrupted or out of sync with my-access. 

# How
These were tests that are present on #62, and not on main. This PR pulls them out into a discrete PR. 