### PR TITLE
Upgrade pypi-publish action to fix TestPyPI/PyPI release

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -77,6 +77,6 @@ jobs:
           rm -f dist/*.sigstore.json
           
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.11
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: ${{ (github.event.release && github.event.release.prerelease) && 'https://test.pypi.org/legacy/' || '' }}


### PR DESCRIPTION
## What
Upgrade the PyPI publish step from the pinned `pypa/gh-action-pypi-publish@v1.8.11` to the maintained `@release/v1` tag.

## Why
The `v1.4.0rc1` TestPyPI release failed with `InvalidDistribution: Metadata is missing required fields: Name, Version` ([run](https://github.com/WattTime/watttime-python-client/actions/runs/28597784994)). The build itself was fine, but modern `setuptools` (via `python -m build`) emits `Metadata-Version: 2.4`, and the old action bundles a `twine` that only supports up to `2.2`, so it could not parse the artifacts. Our own `twine check` step passed because it uses an up-to-date `twine` from pip.

## How
Point the publish step at `pypa/gh-action-pypi-publish@release/v1`, which the pypa project keeps current and which supports newer metadata versions. No other release logic changes; version is still derived from the git tag by setuptools_scm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)