### PR TITLE
Fix IndexError (in _get_chunks) for a zero-length time span (when start == end)

### DIFF
--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -152,6 +152,33 @@ class TestWattTimeBase(unittest.TestCase):
         self.assertIsInstance(parsed_end, datetime)
         self.assertEqual(parsed_end.tzinfo, UTC)
 
+    def test_get_chunks_splits_long_span(self):
+        start = datetime(2025, 1, 1, tzinfo=UTC)
+        end = datetime(2025, 3, 1, tzinfo=UTC)
+
+        chunks = self.base._get_chunks(start, end)
+
+        self.assertEqual(len(chunks), 2)
+        self.assertEqual(chunks[0][0], start)
+        self.assertEqual(chunks[-1][1], end)
+        # API response is inclusive, so chunks must not overlap
+        self.assertEqual(chunks[1][0] - chunks[0][1], timedelta(minutes=5))
+
+    def test_get_chunks_zero_length_span(self):
+        # Requesting a single instant is valid; the API accepts start == end.
+        start = datetime(2025, 1, 15, 6, tzinfo=UTC)
+
+        chunks = self.base._get_chunks(start, start)
+
+        self.assertEqual(chunks, [(start, start)])
+
+    def test_get_chunks_rejects_inverted_span(self):
+        start = datetime(2025, 1, 15, 6, tzinfo=UTC)
+        end = datetime(2025, 1, 14, 6, tzinfo=UTC)
+
+        with self.assertRaises(ValueError):
+            self.base._get_chunks(start, end)
+
     @mock.patch("watttime.requests.Session.post", side_effect=mocked_register)
     def test_mock_register(self, mock_post):
         resp = self.base.register(email=os.getenv("WATTTIME_EMAIL"))
@@ -440,6 +467,16 @@ class TestWattTimeForecast(unittest.TestCase):
         self.assertIn("point_time", df.columns)
         self.assertIn("value", df.columns)
         self.assertIn("generated_at", df.columns)
+
+    def test_historical_forecast_pandas_single_instant(self):
+        # start == end asks for the one forecast run generated at that instant.
+        generated_at = "2025-01-15 06:00Z"
+        df = self.forecast.get_historical_forecast_pandas(
+            generated_at, generated_at, region=REGION
+        )
+        self.assertIsInstance(df, pd.DataFrame)
+        self.assertEqual(df["generated_at"].nunique(), 1)
+        self.assertEqual(parse(generated_at), df["generated_at"].iloc[0])
 
     def test_historical_forecast_pandas_list(self):
         """

--- a/watttime/api.py
+++ b/watttime/api.py
@@ -196,7 +196,20 @@ class WattTimeBase:
 
         Returns:
             List[Tuple[datetime, datetime]]: A list of tuples representing the chunks of time.
+            If start == end, a single zero-length chunk is returned.
+
+        Raises:
+            ValueError: If start is after end.
         """
+        if start > end:
+            raise ValueError(f"start ({start}) must not be after end ({end})")
+
+        # A zero-length span is a valid request: it asks the API for the single
+        # point (or single forecast run) at that instant. The loop below would
+        # produce no chunks at all, so return the span itself as one chunk.
+        if start == end:
+            return [(start, end)]
+
         chunks = []
         while start < end:
             chunk_end = min(end, start + chunk_size)


### PR DESCRIPTION
### Bug: 
get_historical_forecast_pandas(start=X, end=X) raised "IndexError: list index out of range" even though the underlying endpoint accepts start == end and returns the single forecast run generated at that instant. _get_chunks() produces an empty chunk list when start == end (the while loop never runs), then unconditionally indexed the last element:
    `chunks = [(s, e - timedelta(minutes=5)) for s, e in chunks[0:-1]] + [chunks[-1]]`
The same crash affects every caller of _get_chunks: get_historical_jsons, get_historical_forecast_json, and get_fuel_mix_jsons.

### Fix: 
Return the span itself as a single chunk when start == end

### Improvement:
raise ValueError for an inverted span, which previously hit the same IndexError rather than reporting the actual problem. This makes the invalid request fail sooner instead of hitting the API.

### Tests: 
unit coverage for the chunking boundaries plus a live get_historical_forecast_pandas call with start == end.